### PR TITLE
use code not link for Matrix in man

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,1 @@
+sphet.Rproj

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sphet
-Version: 2.1
+Version: 2.1-1
 Encoding: UTF-8
-Date: 2024-12-05
+Date: 2024-12-06
 Title: Estimation of Spatial Autoregressive Models with and without Heteroskedastic Innovations
 Authors@R: c(person("Gianfranco", "Piras", role = c("aut", "cre"), 
             email = "gpiras@mac.com", 

--- a/man/gstslshet.Rd
+++ b/man/gstslshet.Rd
@@ -69,8 +69,8 @@ The GS2SLS residuals are used to obtain a consistent and efficient GM estimator 
 The initial value for the optimization in step 1b is taken to be \code{initial.value}. The initial value in step 1c is the 
 optimal parameter of step 1b. Finally, the initial value for the optimization of step 2b is the optimal parameter of step 1c.
 
-Internally, the object of class \code{listw} is transformed into a \link{Matrix} 
-using the function \link{listw2dgCMatrix}.
+Internally, the object of class \code{listw} is transformed into a \code{Matrix} 
+using the function \code{listw2dgCMatrix}.
 
 
 The expression of the estimated variance covariance matrix of the limiting 

--- a/man/spreg.Rd
+++ b/man/spreg.Rd
@@ -98,7 +98,7 @@ The GS2SLS residuals are used to obtain a consistent and efficient GM estimator 
 The initial value for the optimization in step 1b is taken to be \code{initial.value}. 
 The initial value for the optimization of step 2b is the optimal parameter of step 1b.
 
-Internally, the object of class \code{listw} is transformed into a \link{Matrix} 
+Internally, the object of class \code{listw} is transformed into a \code{Matrix} 
 using the function \link{listw2dgCMatrix}.
 
 For the HAC estimator (Kelejian and Prucha, 2007),  there are four possibilities:


### PR DESCRIPTION
@gpiras I incremented the version and changed `\link{Matrix}` to `\code{Matrix}`; `Matrix` is not a base package, it is recommended. So you cound use `\link[Matrix]{Matrix}` if you like, but `?Matrix::Matrix` is not very informative. 